### PR TITLE
Упрощение этапа установки

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This tool converts Google Keep notes (from [Google Takeout](https://takeout.goog
 
 ## Install requirements
 ```bash
-$ pip3 install Pillow python_magic
+$ pip3 install -r requirements.txt
 ```
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Pillow==8.1.0
+python_magic==0.4.18


### PR DESCRIPTION
## requirements.txt
Добавлен файл requirements.txt.
В README.md вместо строки `pip3 install Pillow python_magic` теперь стоит `pip3 install -r requirements.txt`