### PR TITLE
Adapt for new export format, preserve checklist state, labels and other fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Pillow==8.1.0
 python_magic==0.4.18
+bleach==6.0.0


### PR DESCRIPTION
I was using this to import about 800 Google Keep notes into Apple Notes, which accepts the .enex format (Mac only). I added several fixes/improvements:

* Keep directory in the Google Takeout zip file is now only "Keep", in the past it was "Google Keep"
* Keep labels are added as Evernote tags
* Archived and pinned state are added as tags
* Checklists are now imported as checkboxes and the checked/unchecked state is preserved
* Links are detected automatically now (not sure if Evernote does this automatically on import, but now they are properly linked with an "a" tag on export, which was needed for Apple Notes)
* Attachments are referenced in the note now: before they were added to the note but never referenced anywhere, causing Apple Notes not to show them at all (Evernote might fix this automatically on import but attachments should always be referenced in the note)
* Trashed notes in Keep are ignored during the import
* Note title wasn't properly escaped causing issues on import if a title contains special chars, is fixed now
* Width/height of some images couldn't be determined during the import, I added a try/catch to report the error and continue processing (the image can still be added without explicit width/height)

Thanks for creating this project, it was very helpful for the migration!